### PR TITLE
fix: managed policy arns deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the `CONTRIBUTING.md` file for information on how to contribute.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 5.58.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.24.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
@@ -69,7 +69,7 @@ See the `CONTRIBUTING.md` file for information on how to contribute.
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | = 5.58.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.72.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
@@ -82,87 +82,93 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudfront_distribution.streamlit_distribution](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudfront_distribution) | resource |
-| [aws_cloudwatch_event_bus.streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_event_bus) | resource |
-| [aws_cloudwatch_event_rule.default_event_bus_to_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_rule.invoke_streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.default_event_bus_to_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_event_target.streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_group.streamlit_ecs_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_codebuild_project.streamlit_codebuild_project](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/codebuild_project) | resource |
-| [aws_codepipeline.streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/codepipeline) | resource |
-| [aws_ecr_lifecycle_policy.streamlit_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecr_lifecycle_policy) | resource |
-| [aws_ecr_repository.streamlit_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecr_repository) | resource |
-| [aws_ecs_cluster.streamlit_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_cluster_capacity_providers.streamlit_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecs_cluster_capacity_providers) | resource |
-| [aws_ecs_service.streamlit_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.streamlit_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/ecs_task_definition) | resource |
-| [aws_eip.streamlit_eip](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/eip) | resource |
-| [aws_iam_policy.ecs_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.eventbridge_invoke_streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.streamlit_codebuild_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.ecs_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.eventbridge_invoke_streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.eventbridge_invoke_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.streamlit_codebuild_service_role](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.streamlit_codepipeline_service_role](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/iam_role) | resource |
-| [aws_internet_gateway.streamlit_igw](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/internet_gateway) | resource |
-| [aws_lb.streamlit_alb](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb) | resource |
-| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_listener) | resource |
-| [aws_lb_listener_certificate.https](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_listener_certificate) | resource |
-| [aws_lb_listener_rule.deny_rule](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_listener_rule) | resource |
-| [aws_lb_listener_rule.redirect_rule](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_listener_rule) | resource |
-| [aws_lb_target_group.streamlit_tg](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/lb_target_group) | resource |
-| [aws_nat_gateway.streamlit_ngw](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/nat_gateway) | resource |
-| [aws_route_table.streamlit_route_table_private](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table) | resource |
-| [aws_route_table.streamlit_route_table_public](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.private_subnet1_association](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.private_subnet2_association](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public_subnet1_association](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public_subnet2_association](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/route_table_association) | resource |
-| [aws_s3_bucket.streamlit_codepipeline_artifacts](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_notification.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/s3_bucket_notification) | resource |
-| [aws_s3_bucket_policy.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_versioning.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/s3_bucket_versioning) | resource |
-| [aws_security_group.streamlit_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/security_group) | resource |
-| [aws_security_group.streamlit_ecs_sg](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/security_group) | resource |
-| [aws_subnet.private_subnet1](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/subnet) | resource |
-| [aws_subnet.private_subnet2](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/subnet) | resource |
-| [aws_subnet.public_subnet1](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/subnet) | resource |
-| [aws_subnet.public_subnet2](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/subnet) | resource |
-| [aws_vpc.streamlit_vpc](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc) | resource |
-| [aws_vpc_security_group_egress_rule.streamlit_alb_sg_alb_all_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.streamlit_ecs_sg_alb_all_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_alb_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_http_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_https_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_alb_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_http_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_https_traffic](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_cloudfront_distribution.streamlit_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudwatch_event_bus.streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_bus) | resource |
+| [aws_cloudwatch_event_rule.default_event_bus_to_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.invoke_streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.default_event_bus_to_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.streamlit_ecs_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_codebuild_project.streamlit_codebuild_project](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) | resource |
+| [aws_codepipeline.streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codepipeline) | resource |
+| [aws_ecr_lifecycle_policy.streamlit_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
+| [aws_ecr_repository.streamlit_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecs_cluster.streamlit_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.streamlit_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.streamlit_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.streamlit_ecs_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_eip.streamlit_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_iam_policy.ecs_default_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.eventbridge_invoke_streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.streamlit_codebuild_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ecs_default_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.eventbridge_invoke_streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.eventbridge_invoke_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.streamlit_codebuild_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.streamlit_codepipeline_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachments_exclusive.ecs_default_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.eventbridge_invoke_streamlit_codepipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.eventbridge_invoke_streamlit_event_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.streamlit_codebuild_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.streamlit_codepipeline_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_internet_gateway.streamlit_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_lb.streamlit_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_certificate.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
+| [aws_lb_listener_rule.deny_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_listener_rule.redirect_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_target_group.streamlit_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_nat_gateway.streamlit_ngw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route_table.streamlit_route_table_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.streamlit_route_table_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private_subnet1_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.private_subnet2_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public_subnet1_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public_subnet2_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_s3_bucket.streamlit_codepipeline_artifacts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_notification.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_policy.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_versioning.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_security_group.streamlit_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.streamlit_ecs_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.private_subnet1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.private_subnet2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public_subnet1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public_subnet2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.streamlit_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_vpc_security_group_egress_rule.streamlit_alb_sg_alb_all_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.streamlit_ecs_sg_alb_all_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_alb_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_http_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_alb_sg_https_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_alb_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_http_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.streamlit_ecs_sg_https_traffic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [null_resource.put_s3_object](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.streamlit_cloudfront_invalidation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_sleep.wait_20_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [archive_file.streamlit_assets](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.codebuild_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.codepipeline_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eventbridge_invoke_streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eventbridge_invoke_streamlit_event_bus_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eventbridge_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.streamlit_codebuild_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/region) | data source |
-| [aws_s3_object.streamlit_assets](https://registry.terraform.io/providers/hashicorp/aws/5.58.0/docs/data-sources/s3_object) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.codebuild_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.codepipeline_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_default_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eventbridge_invoke_streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eventbridge_invoke_streamlit_event_bus_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eventbridge_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.streamlit_codebuild_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.streamlit_codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.streamlit_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_object.streamlit_assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_object) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1408,8 +1408,8 @@ resource "aws_iam_role" "ecs_default_role" {
 }
 
 resource "aws_iam_role_policy_attachments_exclusive" "ecs_default_role" {
-  count = var.create_ecs_default_role ? 1 : 0
-  role_name   = aws_iam_role.ecs_default_role.name
+  count       = var.create_ecs_default_role ? 1 : 0
+  role_name   = aws_iam_role.ecs_default_role[count.index].name
   policy_arns = [
     aws_iam_policy.ecs_default_policy[0].arn
   ]

--- a/main.tf
+++ b/main.tf
@@ -1325,9 +1325,6 @@ resource "aws_iam_role" "eventbridge_invoke_streamlit_event_bus" {
   name                  = "${var.app_name}-eventbridge-invoke-streamlit-event-bus"
   assume_role_policy    = data.aws_iam_policy_document.eventbridge_trust_relationship.json
   force_detach_policies = true
-  managed_policy_arns = [
-    aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy.arn,
-  ]
   tags = merge(
     var.tags,
     {
@@ -1335,13 +1332,16 @@ resource "aws_iam_role" "eventbridge_invoke_streamlit_event_bus" {
     },
   )
 }
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.eventbridge_invoke_streamlit_event_bus.name
+  policy_arns = [
+    aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy.arn,
+  ]
+}
 resource "aws_iam_role" "eventbridge_invoke_streamlit_codepipeline" {
   name                  = "${var.app_name}-eventbridge-invoke-streamlit-codepipeline"
   assume_role_policy    = data.aws_iam_policy_document.eventbridge_trust_relationship.json
   force_detach_policies = var.enable_force_detach_policies
-  managed_policy_arns = [
-    aws_iam_policy.eventbridge_invoke_streamlit_codepipeline_policy.arn,
-  ]
   tags = merge(
     var.tags,
     {
@@ -1349,14 +1349,17 @@ resource "aws_iam_role" "eventbridge_invoke_streamlit_codepipeline" {
     },
   )
 }
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.eventbridge_invoke_streamlit_codepipeline.name
+  policy_arns = [
+    aws_iam_policy.eventbridge_invoke_streamlit_codepipeline_policy.arn,
+  ]
+}
 # CodePipeline
 resource "aws_iam_role" "streamlit_codepipeline_service_role" {
   name                  = "${var.app_name}-codepipeline-service-role"
   force_detach_policies = var.enable_force_detach_policies
   assume_role_policy    = data.aws_iam_policy_document.codepipeline_trust_relationship.json
-  managed_policy_arns = [
-    aws_iam_policy.streamlit_codepipeline_policy.arn,
-  ]
   tags = merge(
     var.tags,
     {
@@ -1364,16 +1367,17 @@ resource "aws_iam_role" "streamlit_codepipeline_service_role" {
     },
   )
 }
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.streamlit_codepipeline_service_role.name
+  policy_arns = [
+    aws_iam_policy.streamlit_codepipeline_policy.arn,
+  ]
+}
 # CodeBuild
 resource "aws_iam_role" "streamlit_codebuild_service_role" {
   name                  = "${var.app_name}-codebuild-service-role"
   assume_role_policy    = data.aws_iam_policy_document.codebuild_trust_relationship.json
   force_detach_policies = var.enable_force_detach_policies
-  managed_policy_arns = [
-    aws_iam_policy.streamlit_codebuild_policy.arn,
-    "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
-
-  ]
   tags = merge(
     var.tags,
     {
@@ -1381,7 +1385,13 @@ resource "aws_iam_role" "streamlit_codebuild_service_role" {
     },
   )
 }
-
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.streamlit_codebuild_service_role.name
+  policy_arns = [
+    aws_iam_policy.streamlit_codebuild_policy.arn,
+    "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
+  ]
+}
 # ECS
 resource "aws_iam_role" "ecs_default_role" {
   count = var.create_ecs_default_role ? 1 : 0
@@ -1408,7 +1418,6 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   name = "${var.app_name}-ecs-task-execution-role"
 
   assume_role_policy    = data.aws_iam_policy_document.ecs_tasks_trust_relationship[0].json
-  managed_policy_arns   = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
   force_detach_policies = var.enable_force_detach_policies
 
   tags = merge(
@@ -1417,4 +1426,8 @@ resource "aws_iam_role" "ecs_task_execution_role" {
       Name = "${var.app_name}-ecs-task-execution-role"
     },
   )
+}
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.ecs_task_execution_role.name
+  policy_arns   = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }

--- a/main.tf
+++ b/main.tf
@@ -1389,15 +1389,19 @@ resource "aws_iam_role" "ecs_default_role" {
   assume_role_policy    = data.aws_iam_policy_document.ecs_tasks_trust_relationship[0].json
   force_detach_policies = var.enable_force_detach_policies  
 
-  managed_policy_arns = [
-    aws_iam_policy.ecs_default_policy[0].arn
-  ]
   tags = merge(
     var.tags,
     {
       Name = "${var.app_name}-ecs-default-role"
     },
   )
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.ecs_default_role.name
+  policy_arns = [
+    aws_iam_policy.ecs_default_policy[0].arn
+  ]
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {

--- a/main.tf
+++ b/main.tf
@@ -1408,6 +1408,7 @@ resource "aws_iam_role" "ecs_default_role" {
 }
 
 resource "aws_iam_role_policy_attachments_exclusive" "ecs_default_role" {
+  count = var.create_ecs_default_role ? 1 : 0
   role_name   = aws_iam_role.ecs_default_role.name
   policy_arns = [
     aws_iam_policy.ecs_default_policy[0].arn

--- a/main.tf
+++ b/main.tf
@@ -387,6 +387,7 @@ resource "aws_lb" "streamlit_alb" {
 resource "aws_lb_target_group" "streamlit_tg" {
   name        = "${var.app_name}-tg"
   port        = 80
+  #checkov:skip=CKV_AWS_378:Using HTTP protocol because fronted by CloudFront
   protocol    = "HTTP"
   target_type = "ip"
   vpc_id      = var.create_vpc_resources ? aws_vpc.streamlit_vpc[0].id : var.existing_vpc_id
@@ -524,7 +525,8 @@ resource "aws_cloudfront_distribution" "streamlit_distribution" {
 
   restrictions {
     geo_restriction {
-      restriction_type = "none"
+      restriction_type = "blacklist"
+      locations = []
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1332,7 +1332,7 @@ resource "aws_iam_role" "eventbridge_invoke_streamlit_event_bus" {
     },
   )
 }
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "eventbridge_invoke_streamlit_event_bus" {
   role_name   = aws_iam_role.eventbridge_invoke_streamlit_event_bus.name
   policy_arns = [
     aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy.arn,
@@ -1349,7 +1349,7 @@ resource "aws_iam_role" "eventbridge_invoke_streamlit_codepipeline" {
     },
   )
 }
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "eventbridge_invoke_streamlit_codepipeline" {
   role_name   = aws_iam_role.eventbridge_invoke_streamlit_codepipeline.name
   policy_arns = [
     aws_iam_policy.eventbridge_invoke_streamlit_codepipeline_policy.arn,
@@ -1367,7 +1367,7 @@ resource "aws_iam_role" "streamlit_codepipeline_service_role" {
     },
   )
 }
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "streamlit_codepipeline_service_role" {
   role_name   = aws_iam_role.streamlit_codepipeline_service_role.name
   policy_arns = [
     aws_iam_policy.streamlit_codepipeline_policy.arn,
@@ -1385,7 +1385,7 @@ resource "aws_iam_role" "streamlit_codebuild_service_role" {
     },
   )
 }
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "streamlit_codebuild_service_role" {
   role_name   = aws_iam_role.streamlit_codebuild_service_role.name
   policy_arns = [
     aws_iam_policy.streamlit_codebuild_policy.arn,
@@ -1407,7 +1407,7 @@ resource "aws_iam_role" "ecs_default_role" {
   )
 }
 
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "ecs_default_role" {
   role_name   = aws_iam_role.ecs_default_role.name
   policy_arns = [
     aws_iam_policy.ecs_default_policy[0].arn
@@ -1427,7 +1427,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
     },
   )
 }
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "ecs_task_execution_role" {
   role_name   = aws_iam_role.ecs_task_execution_role.name
   policy_arns   = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,4 @@ output "streamlit_cloudfront_distribution_url" {
 output "azs" {
   description = "A list of availability zones for the region of the current AWS profile."
   value       = data.aws_availability_zones.available.names
-
 }

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 5.58.0"
+      version = ">= 5.72.0"
     }
     awscc = {
       source  = "hashicorp/awscc"


### PR DESCRIPTION
Updating deprecation warning:

```
│ Warning: Argument is deprecated
│ 
│   with module.serverless-streamlit-app.aws_iam_role.eventbridge_invoke_streamlit_event_bus,
│   on .terraform/modules/serverless-streamlit-app/main.tf line 1313, in resource "aws_iam_role" "eventbridge_invoke_streamlit_event_bus":
│ 1313:   managed_policy_arns = [
│ 1314:     aws_iam_policy.eventbridge_invoke_streamlit_event_bus_policy.arn,
│ 1315:   ]
│ 
│ The managed_policy_arns argument is deprecated. Use the aws_iam_role_policy_attachment resource instead. If Terraform shouldexclusively manage all managed policy attachments
│ (the current behavior of this argument), use the aws_iam_role_policy_attachments_exclusive resource as well.
│ 
│ (and 6 more similar warnings elsewhere)
```